### PR TITLE
OpenQA Stability Analysis Tool

### DIFF
--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -157,6 +157,11 @@ class JobData:
             self.job_details = requests.get(self.get_job_api_url(details=True)).json()
         return self.job_details
 
+    def get_job_start_time(self):
+        json_data = self.get_job_details()
+
+        return json_data['job']['t_started']
+
     def get_results(self):
         if self.failures:
             return self.failures

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -191,6 +191,26 @@ class JobData:
 
         return self.failures
 
+    def is_valid(self):
+        json_data = self.get_job_details()
+        job_result = json_data['job']['result']
+        if job_result == "success":
+            return True
+        elif job_result == "failed":
+            has_failures = len(self.get_results()[self.job_name]) > 0
+            all_test_groups_ran = True
+
+            for test_group in json_data['job']['testresults']:
+                if test_group['result'] == 'none':
+                    all_test_groups_ran = False
+
+            # FIXME deal with edge-cases where 'system_tests' passes but no
+            # external results are generated https://openqa.qubes-os.org/tests/20425
+
+            return all_test_groups_ran and has_failures
+        else:
+            return False
+
     def get_children_pruned(self):
         data = requests.get(
             "{}/jobs/{}/".format(OPENQA_API, self.job_id)).json()

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -632,7 +632,7 @@ class OpenQA:
         for job in data['jobs']:
             jobs.append(job['id'])
 
-        return jobs
+        return sorted(jobs)
 
 def setup_environ(args):
     global name_mapping

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -591,6 +591,11 @@ class OpenQA:
     @staticmethod
     def get_latest_job_id(job_type='system_tests_update', build=None,
                           version=None):
+        return OpenQA.get_latest_job_ids(job_type, build, version, n=1)
+
+    @staticmethod
+    def get_latest_job_ids(job_type='system_tests_update', build=None,
+                          version=None, n=100, result=None):
         params = []
         if job_type:
             params.append('test={}'.format(job_type))
@@ -598,6 +603,10 @@ class OpenQA:
             params.append('build={}'.format(build))
         if version:
             params.append('version={}'.format(version))
+        if n:
+            params.append('limit={}'.format(n))
+        if result:
+            params.append('result={}'.format(result))
 
         if params:
             params_string = '?' + "&".join(params)
@@ -605,15 +614,14 @@ class OpenQA:
             params_string = ''
 
         data = requests.get(
-            OPENQA_API + '/jobs/overview' + params_string).json()
+            OPENQA_API + '/jobs' + params_string).json()
 
-        results = []
+        jobs = []
 
-        for job in data:
-            results.append(job['id'])
+        for job in data['jobs']:
+            jobs.append(job['id'])
 
-        return results
-
+        return jobs
 
 def setup_environ(args):
     global name_mapping

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -86,8 +86,13 @@ class TestFailure:
 
         if description is None:
             self.description = None
+            self.error_message = None
+        elif "\n" in description.strip():
+            self.description = None
+            self.error_message = description.strip()
         else:
             self.description = description.strip()
+            self.error_message = self.description
 
     def get_test_url(self):
         return "{}/tests/{}#step/{}/{}".format(

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -600,11 +600,11 @@ class OpenQA:
     @staticmethod
     def get_latest_job_id(job_type='system_tests_update', build=None,
                           version=None):
-        return OpenQA.get_latest_job_ids(job_type, build, version, n=1)
+        return OpenQA.get_latest_job_ids(job_type, build, version, history_len=1)
 
     @staticmethod
     def get_latest_job_ids(job_type='system_tests_update', build=None,
-                          version=None, n=100, result=None, flavor=None):
+                          version=None, history_len=100, result=None, flavor=None):
         params = []
         if job_type:
             params.append('test={}'.format(job_type))
@@ -612,8 +612,8 @@ class OpenQA:
             params.append('build={}'.format(build))
         if version:
             params.append('version={}'.format(version))
-        if n:
-            params.append('limit={}'.format(n))
+        if history_len:
+            params.append('limit={}'.format(history_len))
         if result:
             params.append('result={}'.format(result))
         if flavor:

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -194,7 +194,7 @@ class JobData:
     def is_valid(self):
         json_data = self.get_job_details()
         job_result = json_data['job']['result']
-        if job_result == "success":
+        if job_result == "passed":
             return True
         elif job_result == "failed":
             has_failures = len(self.get_results()[self.job_name]) > 0

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -84,7 +84,7 @@ class TestFailure:
         self.job_id = job_id
         self.test_id = test_id
 
-        if description is None or "\n" in description.strip():
+        if description is None:
             self.description = None
         else:
             self.description = description.strip()

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -158,8 +158,18 @@ class JobData:
 
     def get_job_start_time(self):
         json_data = self.get_job_details()
-
         return json_data['job']['t_started']
+
+    def get_job_parent(self):
+        json_data = self.get_job_details()
+        parents = json_data['job']['parents']['Chained']
+        if len(parents) == 0:
+            raise Exception("Job {} has no parents.".format(self.job_id)\
+                            + " This may happen in some older tests.")
+        if len(parents) > 1:
+            raise Exception("Implementation does not support more than one "\
+                            + "parent job.")
+        return parents[0]
 
     def get_job_details(self):
         if self.job_details is None:

--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -152,15 +152,19 @@ class JobData:
         json_data = self.get_job_details()
         return json_data['job']['settings']['BUILD']
 
-    def get_job_details(self):
-        if self.job_details is None:
-            self.job_details = requests.get(self.get_job_api_url(details=True)).json()
-        return self.job_details
+    def get_job_flavor(self):
+        json_data = self.get_job_details()
+        return json_data['job']['settings']['FLAVOR']
 
     def get_job_start_time(self):
         json_data = self.get_job_details()
 
         return json_data['job']['t_started']
+
+    def get_job_details(self):
+        if self.job_details is None:
+            self.job_details = requests.get(self.get_job_api_url(details=True)).json()
+        return self.job_details
 
     def get_results(self):
         if self.failures:
@@ -600,7 +604,7 @@ class OpenQA:
 
     @staticmethod
     def get_latest_job_ids(job_type='system_tests_update', build=None,
-                          version=None, n=100, result=None):
+                          version=None, n=100, result=None, flavor=None):
         params = []
         if job_type:
             params.append('test={}'.format(job_type))
@@ -612,6 +616,8 @@ class OpenQA:
             params.append('limit={}'.format(n))
         if result:
             params.append('result={}'.format(result))
+        if flavor:
+            params.append('flavor={}'.format(flavor))
 
         if params:
             params_string = '?' + "&".join(params)

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -26,8 +26,7 @@ def get_jobs(test_suite, history_len):
     """
 
     jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
-                                     history_len=history_len, result="failed",
-                                     flavor=FLAVOR)
+                                     history_len=history_len, flavor=FLAVOR)
 
     for job_id in jobs:
         yield JobData(job_id)

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -130,7 +130,8 @@ def test_matches(test_name, test_name_pattern, test_title, test_title_pattern):
         return test_name_matches(test_name, test_name_pattern) and \
             test_title_matches(test_title, test_title_pattern)
     except re.error:
-        print("Error: \"{}/{}\" is not a valid regex".format(test_name_pattern, test_title_pattern))
+        raise Exception("Error: \"{}/{}\" is not a valid regex".\
+            format(test_name_pattern, test_title_pattern))
 
 def test_name_matches(test_name, test_name_pattern):
     return re.search(test_name_pattern, test_name)

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -5,7 +5,8 @@ from fnmatch import fnmatch
 
 HISTORY_LEN = 200
 Q_VERSION = "4.1"
-TEST_SUITE_NAME = "system_tests_splitgpg"
+TEST_SUITE_NAME = "system_tests_network_ipv6"
+FLAVOR = "pull-requests"
 
 def historical_test_failures(test_name, test_title):
     """ Looks at the historical data of a particular test to investigate
@@ -17,7 +18,8 @@ def historical_test_failures(test_name, test_title):
     print("\ton the last {} failed tests".format(HISTORY_LEN))
 
     jobs = OpenQA.get_latest_job_ids(TEST_SUITE_NAME, version=Q_VERSION,
-                                     n=HISTORY_LEN, result="failed")
+                                     n=HISTORY_LEN, result="failed",
+                                     flavor=FLAVOR)
 
     for job_id in jobs:
 
@@ -25,7 +27,9 @@ def historical_test_failures(test_name, test_title):
         result = job.get_results()
         test_failures = result[TEST_SUITE_NAME]
 
-        print("\n# Job {} (from {})".format(job_id, job.get_job_start_time()))
+        print("\n## Job {} (flavor '{}' from {})".format(job_id,
+                                                      job.get_job_flavor(),
+                                                      job.get_job_start_time()))
 
         for test_failure in test_failures:
             if fnmatch(test_failure.name, test_name):

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -4,6 +4,8 @@ import textwrap
 from fnmatch import fnmatch
 
 HISTORY_LEN = 200
+Q_VERSION = "4.1"
+TEST_SUITE_NAME = "system_tests_splitgpg"
 
 def historical_test_failures(test_name, test_title):
     """ Looks at the historical data of a particular test to investigate
@@ -14,17 +16,14 @@ def historical_test_failures(test_name, test_title):
                                                           test_title))
     print("\ton the last {} failed tests".format(HISTORY_LEN))
 
-
-    job_name = "system_tests_splitgpg"
-    jobs = OpenQA.get_latest_job_ids(job_name, version="4.1",
+    jobs = OpenQA.get_latest_job_ids(TEST_SUITE_NAME, version=Q_VERSION,
                                      n=HISTORY_LEN, result="failed")
-
 
     for job_id in jobs:
 
         job = JobData(job_id)
         result = job.get_results()
-        test_failures = result[job_name]
+        test_failures = result[TEST_SUITE_NAME]
 
         print("\n# Job {} (from {})".format(job_id, job.get_job_start_time()))
 
@@ -40,8 +39,6 @@ def historical_test_failures(test_name, test_title):
                     print(test_failure)
                     print("```")
 
-
-
 def main():
     parser = ArgumentParser(
         description="Look for unstable tests")
@@ -50,14 +47,6 @@ def main():
         "--test",
         help="Test Case with wildcard support"
              "(e.g.: TC_00_Direct_*/test_000_version)")
-
-    parser.add_argument(
-        '--build',
-        help="Requires --latest. System build to look for, "
-             "for example 4.0-20190801.1.")
-    parser.add_argument(
-        '--version',
-        help="Requires --latest. System version to look for, for example 4.1.")
 
     args = parser.parse_args()
 

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -469,7 +469,7 @@ def main():
 
     parser.add_argument(
         "--output",
-        help="Select output format (markdown/plot_error/plot_templates/plot_tests)")
+        help="Select output format (report/plot_error/plot_templates/plot_tests)")
 
     parser.add_argument(
         "--outdir",

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -237,13 +237,44 @@ def group_by_error(test):
 
     return result
 
+def group_by_template(test):
+    # obtain template name according to construction format of
+    # https://github.com/QubesOS/qubes-core-admin/blob/f60334/qubes/tests/__init__.py#L1352
+    # Will catch most common tests.
+    template = test.name.split("_")[-1]
+    template = template.split("-pool")[0] # remove trailing "-pool"
+
+    if re.search(r"^[a-z\-]+\-\d+(\-xfce)?$", template): # [template]-[ver]
+        return template
+
+    msg  = "Test's name '{}' doesn't specify a template.\n".format(test.name)
+    msg += "  The test suite may not include template information in the"
+    msg += " test's name."
+    raise Exception(msg)
+
 def plot_group_by_test(title, jobs, test_suite, outfile=None):
     y_fn = lambda test: test.title
     plot_simple(title, jobs, test_suite, y_fn, outfile)
 
 def plot_group_by_template(title, jobs, test_suite, outfile=None):
-    y_fn = lambda test: test.name
-    plot_simple(title, jobs, test_suite, y_fn, outfile)
+    plot_simple(title, jobs, test_suite, group_by_template, outfile)
+
+    def group_by_template(test):
+        # obtain template name according to construction format of
+        # https://github.com/QubesOS/qubes-core-admin/blob/f60334/qubes/tests/__init__.py#L1352
+        # Will catch most common tests.
+        template = test.name.split("_")[-1]
+        template = template.split("-pool")[0] # remove trailing "-pool"
+
+        if re.search(r"^[a-z\-]+\-\d+(\-xfce)?$", template): # [template]-[ver]
+            return template
+
+        msg  = "Test's name '{}' doesn't specify a template.\n".format(test.name)
+        msg += "  The test suite '{}' may not include".format(test_suite)
+        msg += "template information in the test's name."
+        raise Exception(msg)
+
+    plot_simple(title, jobs, test_suite, group_by_template, outfile)
 
 def plot_group_by_worker(title, jobs, test_suite, outfile):
 
@@ -254,7 +285,7 @@ def plot_group_by_worker(title, jobs, test_suite, outfile):
     plot_simple(title, jobs, test_suite, group_by, outfile)
 
 def plot_group_by_error(title, jobs, test_suite, outfile=None):
-    hue_fn=lambda test: test.name
+    hue_fn=group_by_template
     plot_strip(title, jobs, test_suite, group_by_error, hue_fn, outfile)
 
 def plot_simple(title, jobs, test_suite, y_fn, outfile=None):

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -58,10 +58,12 @@ def report_test_failure(job, test_name, test_title, outdir):
                                                     job.get_job_start_time())
     for test_failure in test_failures:
         if not test_title == test_failure.title: # regex title
-            report += "\n\n### {}\n".format(test_failure.title)
-
+            report += "\n\n### [{}/{}]({})\n".format(
+                test_failure.name,
+                test_failure.title,
+                test_failure.get_test_url())
         report += "```python\n"
-        report += str(test_failure)
+        report += str(test_failure.error_message)
         report += "\n```\n"
 
     return report
@@ -202,8 +204,8 @@ def filter_tests_by_error(job, error_pattern):
     filtered_results = []
 
     for test_failure in test_failures:
-        if test_failure.description and \
-            re.search(error_pattern, test_failure.description):
+        if test_failure.error_message and \
+            re.search(error_pattern, test_failure.error_message):
             filtered_results.append(test_failure)
 
     filtered_job = deepcopy(job)
@@ -212,10 +214,10 @@ def filter_tests_by_error(job, error_pattern):
     return filtered_job
 
 def group_by_error(test):
-    if not test.description:
+    if not test.error_message:
         return "no error printed\n(probably a native openQA test)"
 
-    desc_lines = test.description.split("\n")
+    desc_lines = test.error_message.split("\n")
 
     result = ""
     max_chars = 40

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -153,7 +153,7 @@ def plot_simple(title, jobs, test_suite, y_fn):
         y_fn (function(TestFailure)): function to group the results by.
     """
 
-    valid_jobs = set()
+    valid_jobs = set() # jobs with valid results
     groups = set()
     for job in jobs:
         results = job.get_results()[test_suite]
@@ -162,26 +162,29 @@ def plot_simple(title, jobs, test_suite, y_fn):
             valid_jobs.add(job)
 
     # initialize data
+    x_data = []
     y_data = {}
     for test in sorted(groups):
         y_data[test] = [0]*len(valid_jobs)
 
-    x_data = []
     for i, job in enumerate(valid_jobs):
         results = job.get_results()[test_suite]
-        x_data.append(str(job.job_id))
+        x_data.append(job.job_id)
         for test in results:
             y_data[y_fn(test)][i] += 1
 
+    x_data = sorted(x_data)
+    x_data = list(map(str, x_data))
+
     # sort the data by number of failed tests so it the one with the most
     # failures shows at the top of the legend
-    sorted_data = dict(sorted(y_data.items(), key=lambda entry: sum(entry[1]),
+    y_data = dict(sorted(y_data.items(), key=lambda entry: sum(entry[1]),
                        reverse=True))
 
     with plt.style.context('Solarize_Light2'):
-        for key in sorted_data.keys():
+        for key in y_data.keys():
             plt.xticks(rotation=70)
-            plt.plot(list(x_data), sorted_data[key], label=key, linewidth=2)
+            plt.plot(x_data, y_data[key], label=key, linewidth=2)
 
     plt.title(title[1])
     plt.suptitle(title[0])

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -40,15 +40,27 @@ def print_test_failure(job, test_suite, test_name, test_title):
                                                     job.get_job_start_time()))
 
     for test_failure in test_failures:
-        if fnmatch(test_failure.name, test_name):
-            if fnmatch(test_failure.title, test_title):
+        if test_matches(test_failure.name, test_name,\
+                        test_failure.title, test_title):
 
-                if test_title != test_failure.title: # wildcard title
-                    print("\n### {}".format(test_failure.title))
+            if not test_title == test_failure.title: # wildcard title
+                print("\n### {}".format(test_failure.title))
 
-                print("```python")
-                print(test_failure)
-                print("```")
+            print("```python")
+            print(test_failure)
+            print("```")
+        else:
+            print("Warning: no matches for {}/{}".format(test_name, test_title))
+
+def test_matches(test_name, test_name_pattern, test_title, test_title_pattern):
+    return test_name_matches(test_name, test_name_pattern) and \
+           test_title_matches(test_title, test_title_pattern)
+
+def test_name_matches(test_name, test_name_pattern):
+    return fnmatch(test_name, test_name_pattern)
+
+def test_title_matches(test_title, test_title_pattern):
+    return fnmatch(test_title, test_title_pattern)
 
 def main():
     parser = ArgumentParser(

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -125,7 +125,7 @@ def plot_group_by_error(title, jobs, test_suite, outdir):
         desc_lines = test.description.split("\n")
 
         result = ""
-        max_chars = 22
+        max_chars = 40
 
         # attempt to find the line with the relevant result
         for line in reversed(desc_lines):
@@ -166,6 +166,8 @@ def plot_simple(title, jobs, test_suite, outdir, y_fn):
         test_suite (str): test suite.
         y_fn (function(TestFailure)): function to group the results by.
     """
+
+    plt.figure(figsize=(10,7))
 
     groups = set()
     for job in jobs:
@@ -227,6 +229,8 @@ def plot_strip(title, jobs, test_suite, outdir, y_fn, hue_fn):
         y_fn (function(TestFailure)): function to group the results by.
         hue_fn (function(TestFailure)): function to color the results by.
     """
+    plt.figure(figsize=(14,7))
+    plt.subplots_adjust(left = 0.03, right = 0.80)
 
     x_data = []
     y_data = []

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -6,6 +6,7 @@ import re
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd
+import logging
 
 import requests_cache
 requests_cache.install_cache('openqa_cache', backend='sqlite', expire_after=8200)
@@ -246,11 +247,13 @@ def group_by_template(test):
 
     if re.search(r"^[a-z\-]+\-\d+(\-xfce)?$", template): # [template]-[ver]
         return template
+    else:
+        msg  = "Test's name '{}' doesn't specify a template.\n".format(test.name)
+        msg += "  The test suite may not include template information in the"
+        msg += " test's name."
+        logging.warning(msg)
 
-    msg  = "Test's name '{}' doesn't specify a template.\n".format(test.name)
-    msg += "  The test suite may not include template information in the"
-    msg += " test's name."
-    raise Exception(msg)
+        return "unspecifed template"
 
 def plot_group_by_test(title, jobs, test_suite, outfile=None):
     y_fn = lambda test: test.title

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -36,6 +36,9 @@ def get_jobs(test_suite, history_len):
     job_ids = sorted(success_jobs + failed_jobs)
     job_ids = job_ids[-history_len:]
 
+    if len(job_ids) == 0:
+        print("ERROR: no jobs found. Wrong test suite name?")
+
     for job_id in job_ids:
         yield JobData(job_id)
 
@@ -49,16 +52,18 @@ def report_test_failure(job, test_name, test_title, outdir):
     report = ""
 
     if test_failures:
-        report = "\n## Job {} (flavor '{}' from {})".format(job.job_id,
+        report = "\n## Job {} (flavor '{}' from {})\n".format(job.job_id,
                                                     job.get_job_flavor(),
                                                     job.get_job_start_time())
     for test_failure in test_failures:
         if not test_title == test_failure.title: # regex title
-            report += "\n\n### {}".format(test_failure.title)
+            report += "\n\n### {}\n".format(test_failure.title)
 
-        report += "```python"
+        report += "```python\n"
         report += str(test_failure)
-        report += "```"
+        report += "\n```\n"
+
+    return report
 
     if outdir:
         file_path = outdir + "report.md"

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -33,12 +33,11 @@ def historical_test_failures(test_name, test_title):
 
         for test_failure in test_failures:
             if fnmatch(test_failure.name, test_name):
-                if not test_title:
-                    print("\n## {}".format(test_failure.title))
-                    print("```python")
-                    print(test_failure)
-                    print("```")
-                elif fnmatch(test_failure.title, test_title):
+                if fnmatch(test_failure.title, test_title):
+
+                    if test_title != test_failure.title: # wildcard title
+                        print("\n### {}".format(test_failure.title))
+
                     print("```python")
                     print(test_failure)
                     print("```")

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -72,8 +72,8 @@ def main():
 
     parser.add_argument(
         "--test",
-        help="Test Case with wildcard support"
-             "(e.g.: TC_00_Direct_*/test_000_version)")
+        help="Test Case with wildcard support (include \"\")"
+             "(e.g.: \"TC_00_Direct_*/test_000_version)\"")
 
     parser.add_argument(
         "--last",

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -99,7 +99,7 @@ def plot_group_by_error(title, jobs, test_suite):
 
     def group_by_error(test):
         if not test.description:
-            return "no error printed"
+            return "no error printed\n(probably a native openQA test)"
 
         desc_lines = test.description.split("\n")
 

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -145,34 +145,35 @@ def plot_simple(title, jobs, test_suite, y_fn):
         y_fn (function(TestFailure)): function to group the results by.
     """
 
+    valid_jobs = set()
     groups = set()
     for job in jobs:
         results = job.get_results()[test_suite]
         for test in results:
             groups.add(y_fn(test))
+            valid_jobs.add(job)
 
     # initialize data
-    data = {}
+    y_data = {}
     for test in sorted(groups):
-        data[test] = [0]*len(jobs)
+        y_data[test] = [0]*len(valid_jobs)
 
-    for i, job in enumerate(jobs):
+    x_data = []
+    for i, job in enumerate(valid_jobs):
         results = job.get_results()[test_suite]
+        x_data.append(str(job.job_id))
         for test in results:
-            data[y_fn(test)][i] += 1
-
-    job_ids = [job.job_id for job in jobs]
-    job_ids_str = list(map(str, job_ids))
+            y_data[y_fn(test)][i] += 1
 
     # sort the data by number of failed tests so it the one with the most
     # failures shows at the top of the legend
-    sorted_data = dict(sorted(data.items(), key=lambda entry: sum(entry[1]),
+    sorted_data = dict(sorted(y_data.items(), key=lambda entry: sum(entry[1]),
                        reverse=True))
 
     with plt.style.context('Solarize_Light2'):
         for key in sorted_data.keys():
             plt.xticks(rotation=70)
-            plt.plot(job_ids_str, sorted_data[key], label=key, linewidth=2)
+            plt.plot(list(x_data), sorted_data[key], label=key, linewidth=2)
 
     plt.title(title[1])
     plt.suptitle(title[0])

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -219,8 +219,13 @@ def plot_strip(title, jobs, test_suite, y_fn, hue_fn):
                      "#fea032", # consecutive Y values appart
                      "#4fa1ed"]
 
-    df = pd.DataFrame({"x": x_data,
+    job_ids = [job.job_id for job in jobs]
+    job_ids_str = list(map(str, job_ids))
+
+    df = pd.DataFrame({# x is categorical to also show job_ids when successful
+                       "x": pd.Categorical(x_data, categories=job_ids_str),
                        "y": y_data,
+                       # z is categorical to order the legend
                        "z": pd.Categorical(z_data, ordered=True,
                                            categories=sorted(set(z_data)))})
 

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -6,25 +6,17 @@ from fnmatch import fnmatch
 Q_VERSION = "4.1"
 FLAVOR = "pull-requests"
 
-def print_tests_failures(test_suite, history_len, test_name, test_title):
+def get_jobs(test_suite, history_len):
     """
-    Prints the historical data of a particular of job failures for a
-    particular test pattern
+    Gets the historical data of a particular of job failures
     """
-
-    print("Summary:")
-    print("\tLooking for failures of test {}/{}".format(test_name,
-                                                          test_title))
-    print("\ton the last {} failed tests".format(history_len))
-    print("\nsuite: ", test_suite)
 
     jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
                                      history_len=history_len, result="failed",
                                      flavor=FLAVOR)
 
     for job_id in jobs:
-        job = JobData(job_id)
-        print_test_failure(job, test_suite, test_name, test_title)
+        yield JobData(job_id)
 
 def print_test_failure(job, test_suite, test_name, test_title):
     """
@@ -99,7 +91,14 @@ def main():
             exit(1)
 
     if args.test:
-        print_tests_failures(args.suite, history_len, test_name, test_title)
+        print("Summary:")
+        print("\tLooking for failures of test {}/{}".format(test_name,
+                                                            test_title))
+        print("\ton the last {} failed tests".format(history_len))
+        print("\nsuite: ", args.suite)
+
+        for job in get_jobs(args.suite, history_len):
+            print_test_failure(job, args.suite, test_name, test_title)
 
 
 if __name__ == '__main__':

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -161,20 +161,19 @@ def plot_simple(title, jobs, test_suite, y_fn):
             groups.add(y_fn(test))
             valid_jobs.add(job)
 
+    valid_jobs = sorted(valid_jobs, key=lambda entry: entry.job_id)
+
     # initialize data
-    x_data = []
     y_data = {}
     for test in sorted(groups):
         y_data[test] = [0]*len(valid_jobs)
 
     for i, job in enumerate(valid_jobs):
         results = job.get_results()[test_suite]
-        x_data.append(job.job_id)
         for test in results:
             y_data[y_fn(test)][i] += 1
 
-    x_data = sorted(x_data)
-    x_data = list(map(str, x_data))
+    x_data = list(map(lambda job: str(job.job_id), valid_jobs))
 
     # sort the data by number of failed tests so it the one with the most
     # failures shows at the top of the legend

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -245,6 +245,14 @@ def plot_group_by_template(title, jobs, test_suite, outfile=None):
     y_fn = lambda test: test.name
     plot_simple(title, jobs, test_suite, y_fn, outfile)
 
+def plot_group_by_worker(title, jobs, test_suite, outfile):
+
+    def group_by(test):
+        job = JobData(test.job_id)
+        return job.get_job_details()['job']['assigned_worker_id']
+
+    plot_simple(title, jobs, test_suite, group_by, outfile)
+
 def plot_group_by_error(title, jobs, test_suite, outfile=None):
     hue_fn=lambda test: test.name
     plot_strip(title, jobs, test_suite, group_by_error, hue_fn, outfile)
@@ -485,6 +493,9 @@ def main():
     elif args.output == "plot_errors":
         title = "Failure By Error\n" + summary
         plot_group_by_error(title, jobs, args.suite, plot_filepath)
+    elif args.output == "plot_worker":
+        title = "Failure By Worker\n" + summary
+        plot_group_by_worker(title, jobs, args.suite, plot_filepath)
 
     elif args.output == "table_tests":
         report += report_table_tests(jobs, args.outdir)

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -22,13 +22,21 @@ IGNORED_ERRORS = [
 
 def get_jobs(test_suite, history_len):
     """
-    Gets the historical data of a particular of job failures
+    Gets the historical data of a particular test suite
     """
 
-    jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
-                                     history_len=history_len, flavor=FLAVOR)
+    success_jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
+                                     result="passed",  history_len=history_len,
+                                     flavor=FLAVOR)
 
-    for job_id in jobs:
+    failed_jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
+                                        result="failed",
+                                        history_len=history_len, flavor=FLAVOR)
+
+    job_ids = sorted(success_jobs + failed_jobs)
+    job_ids = job_ids[-history_len:]
+
+    for job_id in job_ids:
         yield JobData(job_id)
 
 def print_test_failure(job, test_suite, test_name, test_title):
@@ -310,12 +318,6 @@ def main():
         except ValueError:
             print("Error: {} is not a valid number".format(args.last))
             exit(1)
-
-
-    print("Summary:")
-    print("\tLooking for failures of test {}/{}".format(test_name,
-                                                        test_title))
-    print("\ton the last {} failed tests".format(history_len))
 
     jobs = get_jobs(args.suite, history_len)
     summary = "- suite: {}".format(args.suite)

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -142,19 +142,19 @@ def group_by_error(test):
 
     return result
 
-def plot_group_by_test(title, jobs, test_suite, outdir=None):
+def plot_group_by_test(title, jobs, test_suite, outfile=None):
     y_fn = lambda test: test.title
-    plot_simple(title, jobs, test_suite, y_fn, outdir)
+    plot_simple(title, jobs, test_suite, y_fn, outfile)
 
-def plot_group_by_template(title, jobs, test_suite, outdir=None):
+def plot_group_by_template(title, jobs, test_suite, outfile=None):
     y_fn = lambda test: test.name
-    plot_simple(title, jobs, test_suite, y_fn, outdir)
+    plot_simple(title, jobs, test_suite, y_fn, outfile)
 
-def plot_group_by_error(title, jobs, test_suite, outdir=None):
+def plot_group_by_error(title, jobs, test_suite, outfile=None):
     hue_fn=lambda test: test.name
-    plot_strip(title, jobs, test_suite, group_by_error, hue_fn, outdir)
+    plot_strip(title, jobs, test_suite, group_by_error, hue_fn, outfile)
 
-def plot_simple(title, jobs, test_suite, y_fn, outdir=None):
+def plot_simple(title, jobs, test_suite, y_fn, outfile=None):
     """Plots test results with simple plotting where (x=job, y=y_fn)
 
       ^ (y_fn)
@@ -207,14 +207,14 @@ def plot_simple(title, jobs, test_suite, y_fn, outdir=None):
     plt.ylabel('times test failed')
     plt.legend()
 
-    if outdir:
-        file_path = outdir + "plot.png"
+    if outfile:
+        file_path = outfile
         plt.savefig(file_path)
         print("plot saved at {}".format(file_path))
     else:
         plt.show()
 
-def plot_strip(title, jobs, test_suite, y_fn, hue_fn, outdir=None):
+def plot_strip(title, jobs, test_suite, y_fn, hue_fn, outfile=None):
     """ Plots tests's failures along the jobs axis. Good for telling the
     evolution of a test's failure along time.
     (x=job, y=y_fn, hue=hue_fn)
@@ -282,8 +282,8 @@ def plot_strip(title, jobs, test_suite, y_fn, hue_fn, outdir=None):
     plt.ylabel('times test failed')
     plt.legend(loc="center left")
 
-    if outdir:
-        file_path = outdir + "plot.png"
+    if outfile:
+        file_path = outfile
         plt.savefig(file_path)
         print("plot saved at {}".format(file_path))
     else:
@@ -377,17 +377,28 @@ def main():
         for job in jobs:
             report_test_failure(job, test_name, test_title,
                                 args.outdir)
-    elif args.output == "plot_tests":
+
+    jobs = list(jobs)
+    plot_filepath = args.outdir+"plot.png" if args.outdir else None
+    if args.output == "plot_tests":
         title = "Failure By Test\n" + summary
-        plot_group_by_test(title, list(jobs), args.suite, args.outdir)
+        plot_group_by_test(title, jobs, args.suite, plot_filepath)
     elif args.output == "plot_templates":
         title = "Failure By Template\n" + summary
-        plot_group_by_template(title, list(jobs), args.suite, args.outdir)
+        plot_group_by_template(title, jobs, args.suite, plot_filepath)
     elif args.output == "plot_errors":
         title = "Failure By Error\n" + summary
-        plot_group_by_error(title, list(jobs), args.suite, args.outdir)
+        plot_group_by_error(title, jobs, args.suite, plot_filepath)
     else:
         print("Error: '{}' is not a valid output format".format(args.output))
+
+    if args.outdir:
+        file_path = args.outdir + "report.md"
+        with open(file_path, 'w') as f:
+            f.write(report)
+        print("report saved at {}".format(file_path))
+    else:
+        print(report)
 
 if __name__ == '__main__':
     main()

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -8,9 +8,11 @@ Q_VERSION = "4.1"
 TEST_SUITE_NAME = "system_tests_network_ipv6"
 FLAVOR = "pull-requests"
 
-def historical_test_failures(test_name, test_title):
-    """ Looks at the historical data of a particular test to investigate
-    the reasons why it fails an the frequency """
+def print_tests_failures(test_name, test_title):
+    """
+    Prints the historical data of a particular of job failures for a
+    particular test pattern
+    """
 
     print("Summary:")
     print("\tLooking for failures of test {}/{}".format(test_name,
@@ -22,25 +24,31 @@ def historical_test_failures(test_name, test_title):
                                      flavor=FLAVOR)
 
     for job_id in jobs:
-
         job = JobData(job_id)
-        result = job.get_results()
-        test_failures = result[TEST_SUITE_NAME]
+        print_test_failure(job, test_name, test_title)
 
-        print("\n## Job {} (flavor '{}' from {})".format(job_id,
-                                                      job.get_job_flavor(),
-                                                      job.get_job_start_time()))
+def print_test_failure(job, test_name, test_title):
+    """
+    Prints the failures of a particular test pattern
+    """
 
-        for test_failure in test_failures:
-            if fnmatch(test_failure.name, test_name):
-                if fnmatch(test_failure.title, test_title):
+    result = job.get_results()
+    test_failures = result[TEST_SUITE_NAME]
 
-                    if test_title != test_failure.title: # wildcard title
-                        print("\n### {}".format(test_failure.title))
+    print("\n## Job {} (flavor '{}' from {})".format(job.job_id,
+                                                    job.get_job_flavor(),
+                                                    job.get_job_start_time()))
 
-                    print("```python")
-                    print(test_failure)
-                    print("```")
+    for test_failure in test_failures:
+        if fnmatch(test_failure.name, test_name):
+            if fnmatch(test_failure.title, test_title):
+
+                if test_title != test_failure.title: # wildcard title
+                    print("\n### {}".format(test_failure.title))
+
+                print("```python")
+                print(test_failure)
+                print("```")
 
 def main():
     parser = ArgumentParser(
@@ -60,7 +68,7 @@ def main():
         test_title = "*"
 
     if args.test:
-        historical_test_failures(test_name, test_title)
+        print_tests_failures(test_name, test_title)
 
 
 if __name__ == '__main__':

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -1,6 +1,7 @@
 from github_reporting import OpenQA, JobData, TestFailure
 from argparse import ArgumentParser
 import textwrap
+from fnmatch import fnmatch
 
 HISTORY_LEN = 200
 
@@ -28,14 +29,13 @@ def historical_test_failures(test_name, test_title):
         print("\n# Job {} (from {})".format(job_id, job.get_job_start_time()))
 
         for test_failure in test_failures:
-            if test_name == test_failure.name:
-
+            if fnmatch(test_failure.name, test_name):
                 if not test_title:
                     print("\n## {}".format(test_failure.title))
                     print("```python")
                     print(test_failure)
                     print("```")
-                elif test_title == test_failure.title:
+                elif fnmatch(test_failure.title, test_title):
                     print("```python")
                     print(test_failure)
                     print("```")
@@ -48,7 +48,8 @@ def main():
 
     parser.add_argument(
         "--test",
-        help="Test Case (e.g.: TC_00_Direct_debian-10/test_000_version)")
+        help="Test Case with wildcard support"
+             "(e.g.: TC_00_Direct_*/test_000_version)")
 
     parser.add_argument(
         '--build',
@@ -64,7 +65,7 @@ def main():
         (test_name, test_title) = args.test.split('/')
     except ValueError:
         test_name = args.test
-        test_title = None
+        test_title = "*"
 
     if args.test:
         historical_test_failures(test_name, test_title)

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -62,7 +62,7 @@ def print_test_failure(job, test_suite, test_name, test_title):
 def filter_valid_job(job):
     return job.is_valid()
 
-def filter_tests(job, test_suite, test_name, test_title):
+def filter_tests_by_name(job, test_suite, test_name, test_title):
     """
     Filters out tests that don't match a particular test pattern
     """
@@ -327,8 +327,8 @@ def main():
 
     # apply filters
     if args.test:
-        tests_filter = lambda job: filter_tests(job, args.suite,
-                                            test_name, test_title)
+        tests_filter = lambda job: filter_tests_by_name(job, args.suite,
+                                                        test_name, test_title)
         jobs = map(tests_filter, jobs)
         summary += "- tests matching: {}/{}\n".format(test_name, test_title)
 

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -264,23 +264,6 @@ def plot_group_by_test(title, jobs, test_suite, outfile=None):
 def plot_group_by_template(title, jobs, test_suite, outfile=None):
     plot_simple(title, jobs, test_suite, group_by_template, outfile)
 
-    def group_by_template(test):
-        # obtain template name according to construction format of
-        # https://github.com/QubesOS/qubes-core-admin/blob/f60334/qubes/tests/__init__.py#L1352
-        # Will catch most common tests.
-        template = test.name.split("_")[-1]
-        template = template.split("-pool")[0] # remove trailing "-pool"
-
-        if re.search(r"^[a-z\-]+\-\d+(\-xfce)?$", template): # [template]-[ver]
-            return template
-
-        msg  = "Test's name '{}' doesn't specify a template.\n".format(test.name)
-        msg += "  The test suite '{}' may not include".format(test_suite)
-        msg += "template information in the test's name."
-        raise Exception(msg)
-
-    plot_simple(title, jobs, test_suite, group_by_template, outfile)
-
 def plot_group_by_worker(title, jobs, test_suite, outfile):
 
     def group_by(test):

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -185,8 +185,7 @@ def plot_simple(title, jobs, test_suite, y_fn):
             plt.xticks(rotation=70)
             plt.plot(x_data, y_data[key], label=key, linewidth=2)
 
-    plt.title(title[1])
-    plt.suptitle(title[0])
+    plt.title(title)
     plt.xlabel('job')
     plt.ylabel('times test failed')
     plt.legend()
@@ -253,8 +252,7 @@ def plot_strip(title, jobs, test_suite, y_fn, hue_fn):
         tick.set_fontsize(8)
         plt.axhline(y = i, linewidth=0.3, color = color, linestyle = '-')
 
-    plt.title(title[1])
-    plt.suptitle(title[0])
+    plt.title(title)
     plt.xlabel('job')
     plt.ylabel('times test failed')
     plt.legend()
@@ -343,13 +341,13 @@ def main():
         for job in jobs:
             print_test_failure(job, args.suite, test_name, test_title)
     elif args.output == "plot_tests":
-        title = ["Failure By Test", summary]
+        title = "Failure By Test\n" + summary
         plot_group_by_test(title, list(jobs), args.suite)
     elif args.output == "plot_templates":
-        title = ["Failure By Template", summary]
+        title = "Failure By Template\n" + summary
         plot_group_by_template(title, list(jobs), args.suite)
     elif args.output == "plot_errors":
-        title = ["Failure By Error", summary]
+        title = "Failure By Error\n" + summary
         plot_group_by_error(title, list(jobs), args.suite)
     else:
         print("Error: '{}' is not a valid output format".format(args.output))

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -5,6 +5,10 @@ from fnmatch import fnmatch
 from copy import deepcopy
 import re
 
+import requests_cache
+requests_cache.install_cache('openqa_cache', backend='sqlite', expire_after=8200)
+
+
 Q_VERSION = "4.1"
 FLAVOR = "pull-requests"
 

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -3,11 +3,10 @@ from argparse import ArgumentParser
 import textwrap
 from fnmatch import fnmatch
 
-HISTORY_LEN = 200
 Q_VERSION = "4.1"
 FLAVOR = "pull-requests"
 
-def print_tests_failures(test_suite, test_name, test_title):
+def print_tests_failures(test_suite, history_len, test_name, test_title):
     """
     Prints the historical data of a particular of job failures for a
     particular test pattern
@@ -16,11 +15,11 @@ def print_tests_failures(test_suite, test_name, test_title):
     print("Summary:")
     print("\tLooking for failures of test {}/{}".format(test_name,
                                                           test_title))
-    print("\ton the last {} failed tests".format(HISTORY_LEN))
+    print("\ton the last {} failed tests".format(history_len))
     print("\nsuite: ", test_suite)
 
     jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
-                                     n=HISTORY_LEN, result="failed",
+                                     history_len=history_len, result="failed",
                                      flavor=FLAVOR)
 
     for job_id in jobs:
@@ -76,6 +75,12 @@ def main():
         help="Test Case with wildcard support"
              "(e.g.: TC_00_Direct_*/test_000_version)")
 
+    parser.add_argument(
+        "--last",
+        nargs='?',
+        help="Last N failed tests"
+                "(e.g.: 100)")
+
     args = parser.parse_args()
 
     try:
@@ -84,8 +89,17 @@ def main():
         test_name = args.test
         test_title = "*"
 
+    if not args.last:
+        history_len = 100
+    else:
+        try:
+            history_len = int(args.last)
+        except ValueError:
+            print("Error: {} is not a valid number".format(args.last))
+            exit(1)
+
     if args.test:
-        print_tests_failures(args.suite, test_name, test_title)
+        print_tests_failures(args.suite, history_len, test_name, test_title)
 
 
 if __name__ == '__main__':

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -508,14 +508,17 @@ def main():
 
     # output format
     report = ""
+
+    # accumulate jobs for outputs that don't support generators
+    if args.output not in ["report"]:
+        jobs = list(jobs)
+        plot_filepath = args.outdir+"plot.png" if args.outdir else None
+
     if args.output == "report":
         for job in jobs:
-            report_test_failure(job, test_name, test_title,
-                                args.outdir)
-
-    jobs = list(jobs)
-    plot_filepath = args.outdir+"plot.png" if args.outdir else None
-    if args.output == "plot_tests":
+            report += report_test_failure(job, test_name, test_title,
+                                          args.outdir)
+    elif args.output == "plot_tests":
         title = "Failure By Test\n" + summary
         plot_group_by_test(title, jobs, args.suite, plot_filepath)
     elif args.output == "plot_templates":

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -1,0 +1,74 @@
+from github_reporting import OpenQA, JobData, TestFailure
+from argparse import ArgumentParser
+import textwrap
+
+HISTORY_LEN = 200
+
+def historical_test_failures(test_name, test_title):
+    """ Looks at the historical data of a particular test to investigate
+    the reasons why it fails an the frequency """
+
+    print("Summary:")
+    print("\tLooking for failures of test {}/{}".format(test_name,
+                                                          test_title))
+    print("\ton the last {} failed tests".format(HISTORY_LEN))
+
+
+    job_name = "system_tests_splitgpg"
+    jobs = OpenQA.get_latest_job_ids(job_name, version="4.1",
+                                     n=HISTORY_LEN, result="failed")
+
+
+    for job_id in jobs:
+
+        job = JobData(job_id)
+        result = job.get_results()
+        test_failures = result[job_name]
+
+        print("\n# Job {} (from {})".format(job_id, job.get_job_start_time()))
+
+        for test_failure in test_failures:
+            if test_name == test_failure.name:
+
+                if not test_title:
+                    print("\n## {}".format(test_failure.title))
+                    print("```python")
+                    print(test_failure)
+                    print("```")
+                elif test_title == test_failure.title:
+                    print("```python")
+                    print(test_failure)
+                    print("```")
+
+
+
+def main():
+    parser = ArgumentParser(
+        description="Look for unstable tests")
+
+    parser.add_argument(
+        "--test",
+        help="Test Case (e.g.: TC_00_Direct_debian-10/test_000_version)")
+
+    parser.add_argument(
+        '--build',
+        help="Requires --latest. System build to look for, "
+             "for example 4.0-20190801.1.")
+    parser.add_argument(
+        '--version',
+        help="Requires --latest. System version to look for, for example 4.1.")
+
+    args = parser.parse_args()
+
+    try:
+        (test_name, test_title) = args.test.split('/')
+    except ValueError:
+        test_name = args.test
+        test_title = None
+
+    if args.test:
+        historical_test_failures(test_name, test_title)
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -58,6 +58,10 @@ def print_test_failure(job, test_suite, test_name, test_title):
         print(test_failure)
         print("```")
 
+
+def filter_valid_job(job):
+    return job.is_valid()
+
 def filter_tests(job, test_suite, test_name, test_title):
     """
     Filters out tests that don't match a particular test pattern
@@ -76,15 +80,6 @@ def filter_tests(job, test_suite, test_name, test_title):
     filtered_job.failures[job.get_job_name()] = filtered_results
 
     return filtered_job
-
-def filter_jobs_invalid_tests(job, test_suite):
-    """
-    Filter that excludes jobs which don't have valid results
-    """
-    if job.get_results()[test_suite]:
-        return True
-    else:
-        return False
 
 def filter_tests_by_error(job, test_suite, error_pattern):
     """
@@ -327,6 +322,8 @@ def main():
     jobs = get_jobs(args.suite, history_len)
     summary = "- suite: {}".format(args.suite)
 
+    # remove invalid jobs
+    jobs = filter(filter_valid_job, jobs)
 
     # apply filters
     if args.test:
@@ -340,10 +337,6 @@ def main():
                                                          args.error)
         jobs = map(tests_filter, jobs)
         summary += "- error matches: {}\n".format(args.error)
-
-    # at the end of filtering, remove jobs with only invalid tests
-    jobs_filter = lambda job: filter_jobs_invalid_tests(job, args.suite)
-    jobs = filter(jobs_filter, jobs)
 
     # output format
     if args.output == "report":

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -185,7 +185,7 @@ def plot_simple(title, jobs, test_suite, outdir, y_fn):
         for test in results:
             y_data[y_fn(test)][i] += 1
 
-    x_data = list(map(lambda job: str(job.job_id), jobs))
+    x_data = list(map(lambda job: str(job.get_job_parent()), jobs))
 
     # sort the data by number of failed tests so it the one with the most
     # failures shows at the top of the legend
@@ -198,7 +198,7 @@ def plot_simple(title, jobs, test_suite, outdir, y_fn):
             plt.plot(x_data, y_data[key], label=key, linewidth=2)
 
     plt.title(title)
-    plt.xlabel('job')
+    plt.xlabel('parent job')
     plt.ylabel('times test failed')
     plt.legend()
 

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -5,10 +5,9 @@ from fnmatch import fnmatch
 
 HISTORY_LEN = 200
 Q_VERSION = "4.1"
-TEST_SUITE_NAME = "system_tests_network_ipv6"
 FLAVOR = "pull-requests"
 
-def print_tests_failures(test_name, test_title):
+def print_tests_failures(test_suite, test_name, test_title):
     """
     Prints the historical data of a particular of job failures for a
     particular test pattern
@@ -18,22 +17,23 @@ def print_tests_failures(test_name, test_title):
     print("\tLooking for failures of test {}/{}".format(test_name,
                                                           test_title))
     print("\ton the last {} failed tests".format(HISTORY_LEN))
+    print("\nsuite: ", test_suite)
 
-    jobs = OpenQA.get_latest_job_ids(TEST_SUITE_NAME, version=Q_VERSION,
+    jobs = OpenQA.get_latest_job_ids(test_suite, version=Q_VERSION,
                                      n=HISTORY_LEN, result="failed",
                                      flavor=FLAVOR)
 
     for job_id in jobs:
         job = JobData(job_id)
-        print_test_failure(job, test_name, test_title)
+        print_test_failure(job, test_suite, test_name, test_title)
 
-def print_test_failure(job, test_name, test_title):
+def print_test_failure(job, test_suite, test_name, test_title):
     """
     Prints the failures of a particular test pattern
     """
 
     result = job.get_results()
-    test_failures = result[TEST_SUITE_NAME]
+    test_failures = result[test_suite]
 
     print("\n## Job {} (flavor '{}' from {})".format(job.job_id,
                                                     job.get_job_flavor(),
@@ -55,6 +55,11 @@ def main():
         description="Look for unstable tests")
 
     parser.add_argument(
+        "--suite",
+        help="Test suite name"
+             "(e.g.: system_tests_splitgpg)")
+
+    parser.add_argument(
         "--test",
         help="Test Case with wildcard support"
              "(e.g.: TC_00_Direct_*/test_000_version)")
@@ -68,7 +73,7 @@ def main():
         test_title = "*"
 
     if args.test:
-        print_tests_failures(test_name, test_title)
+        print_tests_failures(args.suite, test_name, test_title)
 
 
 if __name__ == '__main__':

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -39,13 +39,13 @@ def get_jobs(test_suite, history_len):
     for job_id in job_ids:
         yield JobData(job_id)
 
-def report_test_failure(job, test_suite, test_name, test_title, outdir):
+def report_test_failure(job, test_name, test_title, outdir):
     """
     Prints the failures of a particular test pattern
     """
 
     result = job.get_results()
-    test_failures = result[test_suite]
+    test_failures = result[job.get_job_name()]
     report = ""
 
     if test_failures:
@@ -72,12 +72,12 @@ def report_test_failure(job, test_suite, test_name, test_title, outdir):
 def filter_valid_job(job):
     return job.is_valid()
 
-def filter_tests_by_name(job, test_suite, test_name, test_title):
+def filter_tests_by_name(job, test_name, test_title):
     """
     Filters out tests that don't match a particular test pattern
     """
     results = job.get_results()
-    test_failures = results[test_suite]
+    test_failures = results[job.get_job_name()]
 
     filtered_results = []
 
@@ -91,12 +91,12 @@ def filter_tests_by_name(job, test_suite, test_name, test_title):
 
     return filtered_job
 
-def filter_tests_by_error(job, test_suite, error_pattern):
+def filter_tests_by_error(job, error_pattern):
     """
     Filters through tests that have a certain error message pattern
     """
     results = job.get_results()
-    test_failures = results[test_suite]
+    test_failures = results[job.get_job_name()]
 
     filtered_results = []
 
@@ -171,7 +171,7 @@ def plot_simple(title, jobs, test_suite, outdir, y_fn):
 
     groups = set()
     for job in jobs:
-        results = job.get_results()[test_suite]
+        results = job.get_results()[job.get_job_name()]
         for test in results:
             groups.add(y_fn(test))
 
@@ -181,7 +181,7 @@ def plot_simple(title, jobs, test_suite, outdir, y_fn):
         y_data[test] = [0]*len(jobs)
 
     for i, job in enumerate(jobs):
-        results = job.get_results()[test_suite]
+        results = job.get_results()[job.get_job_name()]
         for test in results:
             y_data[y_fn(test)][i] += 1
 
@@ -237,7 +237,7 @@ def plot_strip(title, jobs, test_suite, outdir, y_fn, hue_fn):
     z_data = []
 
     for job in jobs:
-        results = job.get_results()[test_suite]
+        results = job.get_results()[job.job_name]
         for test in results:
             x_data.append((str(job.job_id)))
             y_data.append(y_fn(test))
@@ -357,21 +357,20 @@ def main():
 
     # apply filters
     if args.test:
-        tests_filter = lambda job: filter_tests_by_name(job, args.suite,
-                                                        test_name, test_title)
+        tests_filter = lambda job: filter_tests_by_name(job, test_name,
+                                                        test_title)
         jobs = map(tests_filter, jobs)
         summary += "- tests matching: {}/{}\n".format(test_name, test_title)
 
     if args.error:
-        tests_filter = lambda job: filter_tests_by_error(job, args.suite,\
-                                                         args.error)
+        tests_filter = lambda job: filter_tests_by_error(job, args.error)
         jobs = map(tests_filter, jobs)
         summary += "- error matches: {}\n".format(args.error)
 
     # output format
     if args.output == "report":
         for job in jobs:
-            report_test_failure(job, args.suite, test_name, test_title,
+            report_test_failure(job, test_name, test_title,
                                 args.outdir)
     elif args.output == "plot_tests":
         title = "Failure By Test\n" + summary

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -114,7 +114,7 @@ def plot_group_by_error(title, jobs, test_suite):
                 continue
             else:
                 if result: # last two lines
-                    result = line[:max_chars] + "..." + result
+                    result = line[:max_chars] + "...\n" + result
                     break
                 else:
                     result = line[:max_chars] + "..."

--- a/utils/openqa_investigator.py
+++ b/utils/openqa_investigator.py
@@ -339,9 +339,9 @@ def plot_strip(title, jobs, test_suite, y_fn, hue_fn, outfile=None):
     for job in jobs:
         results = job.get_results()[job.job_name]
         for test in results:
-            x_data.append((str(job.job_id)))
-            y_data.append(y_fn(test))
-            z_data.append(hue_fn(test))
+            x_data += [str(job.job_id)]
+            y_data += [y_fn(test)]
+            z_data += [hue_fn(test)]
 
     hue_palette = sns.color_palette("tab20", n_colors=len(set(z_data)))
     tests_palette = ["#ff6c6b", # alternate through 3 colors to be able to tell


### PR DESCRIPTION
Adds the util for analyzing the stability of tests. It analyses historical test data from openqa.qubes-os.org outputs results in several formats:
  - markdown table report
  - markdown reports of all the matching results
  - plot of errors (last two traceback lines)
  - plot of templates
  - plot of failures by test title


### Configuration parameters
  - **test suite** (e.g. `--suite system_tests_splitgpg`)
  - **test name** - (e.g. --test "VmIPv6Networking_fedora-34/test_.*"
  - **error regex** - if you're looking for an error of a particular type (e.g. `--error ".*dogtail.*"`)
  - **approx. history length** - how far you want to go in historical data (e.g. `--last 20`)
  - **openqa job group** -  currently hardcoded to ["pull requests"](https://openqa.qubes-os.org/group_overview/11)


### Example plot

![](https://user-images.githubusercontent.com/47065258/136524366-01c39d19-4eaa-4bc9-b7b7-95ab31178618.png)

### Future work
Future work will be integrating this with `github_reporting.py` such that it produces useful information on new errors.