### PR TITLE
convert_junit.py: add support for pytest JUnit format

### DIFF
--- a/extra-files/convert_junit.py
+++ b/extra-files/convert_junit.py
@@ -44,7 +44,7 @@ def main():
             extract_testcases(testsuite, testcases)
     else:
         # Malformed XML: no <testsuites> root (nose2 output)
-        extract_testcases(testsuite, testcases)
+        extract_testcases(xml_root, testcases)
 
     output_xml = ElementTree.Element('testsuites')
     for classname in testcases:


### PR DESCRIPTION
The script was originally build to support output from nose2's interpretation of the JUnitXML format. However, it produces malformed XML without a root '<testsuites>' element. Therefore when parsing pytest's JUnitXML files it does not find any test cases in the XML root since they are contained in the respective <testuite>. This adds a condition to search for test cases inside each testsuite.
    
Fixes #31
