### PR TITLE
Securedrop test updater adjustments

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -182,7 +182,6 @@ if (check_var('SECUREDROP_INSTALL', '1')) {
     my $args = OpenQA::Test::RunArgs->new();
     $args->{whonix_gw_override} = 'sd-whonix';
     autotest::loadtest("tests/whonix_firstrun.pm", name =>"Setup_sd-whonix",  run_args => $args);
-    autotest::loadtest("tests/securedrop/install_workstation_updates.pm");
 } elsif (check_var('SECUREDROP_TEST', "test_dom0")) {
     autotest::loadtest("tests/securedrop/test_dom0.pm");
 } elsif (check_var('SECUREDROP_TEST', "test_gui")) {
@@ -190,6 +189,8 @@ if (check_var('SECUREDROP_INSTALL', '1')) {
     # autotest::loadtest("tests/securedrop/server_setup.pm");
     # autotest::loadtest("tests/securedrop/server_start.pm");
     # autotest::loadtest("tests/securedrop/test_gui_basic.pm");
+ } elsif (check_var('SECUREDROP_DEV_NIGHTLY', "1")) {
+    autotest::loadtest("tests/securedrop/install_workstation_updates.pm");
 }
 
 if (get_var('DISPVM_PRELOAD')) {

--- a/tests/securedrop/install_workstation_updates.pm
+++ b/tests/securedrop/install_workstation_updates.pm
@@ -36,7 +36,7 @@ sub run {
     # Go through launcher
     assert_and_click("securedrop-launcher");
     assert_screen("securedrop-launcher-updates-in-progress", timeout => 10);
-    assert_screen("securedrop-launcher-updates-complete", timeout => 1200);
+    assert_screen("securedrop-launcher-updates-complete", timeout => 1500);
     if (check_screen("securedrop-launcher-updates-complete-reboot")) {
         assert_and_click("securedrop-launcher-updates-complete-reboot");
         $self->handle_system_startup;


### PR DESCRIPTION
Removes the SecureDrop updater test from the regular `SECUREDROP_INSTALL` run and adds to a TBD SecureDrop nightly updates test. Waiting for a stamp of approval from a SD team member. Will move out of draft once ready for final "review" / merging.

Towards https://github.com/freedomofpress/securedrop-workstation/issues/1379
Fixes https://github.com/freedomofpress/securedrop-workstation/issues/1376 (or rather, suppresses the issue).

We're not ready yet for the nightly run, but we're leaving a placeholder. So there is no need to set that one up just yet.

Test running as https://openqa.qubes-os.org/tests/148159. It's functionally equivalent to [148000](https://openqa.qubes-os.org/tests/148000#) which already passed.