### PR TITLE
Use failure name as upload failure can be empty

### DIFF
--- a/utils/github_reporting.py
+++ b/utils/github_reporting.py
@@ -91,7 +91,7 @@ def format_results(results, jobs, reference_jobs=None, instability_analysis=None
             fails = results[k]
             add_to_output = ""
             for fail in fails:
-                if fail in upload_failures:
+                if fail.name == "system_tests":
                     continue
                 if fail.regression and not fail.unstable:
                     add_to_output += '  * ' + str(fail) + '\n'
@@ -109,7 +109,7 @@ def format_results(results, jobs, reference_jobs=None, instability_analysis=None
                 continue
             add_to_output = ""
             for fail in results[k]:
-                if fail.fixed or fail in upload_failures:
+                if fail.fixed or fail.name == "system_tests":
                     continue
                 if fail.unstable:
                     add_to_output += '  * [unstable] ' + str(fail) + '\n'


### PR DESCRIPTION
For: https://github.com/QubesOS/openqa-tests-qubesos/pull/40

---

Compared the output look at the edit of qubesos-bot from 20 hours ago on https://github.com/QubesOS/qubes-core-admin-client/pull/332.

```sh
python3 utils/github_reporting.py --package-list utils/github_package_mapping.json --latest --build 2025091804-4.3 --flavor pull-requests --version 4.3 --compare-to-build 2025081011-4.3 --show-results-only --verbose --db-path /tmp/db
```

# OpenQA test summary
Complete test suite and dependencies: https://openqa.qubes-os.org/tests/overview?distri=qubesos&version=4.3&build=2025091804-4.3&flavor=pull-requests

Test run included the following:
- https://github.com/QubesOS/qubes-core-admin-client/pull/332 (https://github.com/QubesOS/qubes-core-admin-client/pull/332/commits/40487bcb59ff4a704248144f4783ce0b0e1532b8)
- https://github.com/QubesOS/qubes-core-admin/pull/722 (https://github.com/QubesOS/qubes-core-admin/pull/722/commits/fb172b5bf25f7f5612ba4b9f0aa611efb1e43c6e)
- https://github.com/QubesOS/qubes-core-admin/pull/729 (https://github.com/QubesOS/qubes-core-admin/pull/729/commits/7f335d93fd588e6e9f06d9eec8f2a8bcb36979f3)
- https://github.com/QubesOS/qubes-core-admin/pull/731 (https://github.com/QubesOS/qubes-core-admin/pull/731/commits/e6a13edc7f09beb01b2d1c6fb39850bc40b7170b)
- https://github.com/QubesOS/qubes-core-admin/pull/734 (https://github.com/QubesOS/qubes-core-admin/pull/734/commits/1aef6907c731ce757e4d48c2c089d54b0d6e0048)
- https://github.com/QubesOS/qubes-core-agent-linux/pull/603 (https://github.com/QubesOS/qubes-core-agent-linux/pull/603/commits/78e8b6c940e39081026145d607d17784cac880e6)
- https://github.com/QubesOS/qubes-desktop-linux-manager/pull/275 (https://github.com/QubesOS/qubes-desktop-linux-manager/pull/275/commits/fb275e9b4b2a3931d3afef138be967c0b7957539)
- https://github.com/QubesOS/qubes-desktop-linux-menu/pull/57 (https://github.com/QubesOS/qubes-desktop-linux-menu/pull/57/commits/aa4fdf650f82bdc3019caf0ea677ffa8bd9c5efb)
- https://github.com/QubesOS/qubes-desktop-linux-menu/pull/61 (https://github.com/QubesOS/qubes-desktop-linux-menu/pull/61/commits/65f164a1e9bd56b70522cd872519805cb0c6c09e)
- https://github.com/QubesOS/qubes-manager/pull/398 (https://github.com/QubesOS/qubes-manager/pull/398/commits/679eff400bd0de4887f0bb61de34250a1f842709)
- https://github.com/QubesOS/qubes-manager/pull/428 (https://github.com/QubesOS/qubes-manager/pull/428/commits/36e7630dc1018eb0357e9e153a70a71c0ea7828f)

## New failures
Compared to: https://openqa.qubes-os.org/tests/overview?distri=qubesos&version=4.3&build=2025081011-4.3&flavor=update
* system_tests_network
  * VmNetworking_fedora-42-xfce: [test_001_simple_networking_paused](https://openqa.qubes-os.org/tests/153691#step/VmNetworking_fedora-42-xfce/2) (failure)
 `AssertionError: 1 != 0 : Ping by IP on netvm=something -> netvm=som...`

* system_tests_backup
  * TC_00_Backup: [test_100_backup_dom0_no_restore](https://openqa.qubes-os.org/tests/153692#step/TC_00_Backup/7) (failure)
 `AssertionError: QubesException during backup_prepare: Can not backu...`

  * TC_00_Backup: [test_101_backup_dom0_to_homedir](https://openqa.qubes-os.org/tests/153692#step/TC_00_Backup/8) (failure)
 `AssertionError: QubesException during backup_prepare: Can not backu...`

* system_tests_pvgrub_salt_storage
  * StorageReflinkOnBtrfs: [test_003_snapshot](https://openqa.qubes-os.org/tests/153694#step/StorageReflinkOnBtrfs/4) (error + timeout + cleanup)
 `qubes.exc.QubesVMShutdownTimeoutError: Domain shutdown timed out: '...`

* system_tests_usbproxy
  * TC_20_USBProxy_core3_debian-13-xfce: [test_060_auto_detach_on_remove](https://openqa.qubes-os.org/tests/153699#step/TC_20_USBProxy_core3_debian-13-xfce/8) (failure)
 `AssertionError: 0 == 0 : Device disconnection failed`

* system_tests_network_ipv6
  * VmIPv6Networking_debian-13-xfce: [test_001_simple_networking_paused](https://openqa.qubes-os.org/tests/153701#step/VmIPv6Networking_debian-13-xfce/2) (failure)
 `AssertionError: 1 != 0 : Ping by IP on netvm=something -> netvm=som...`

* system_tests_qwt_win10_seamless@hw13
  * windows_clipboard_and_filecopy: [unnamed test](https://openqa.qubes-os.org/tests/153722#step/windows_clipboard_and_filecopy/71) (unknown)
  * windows_clipboard_and_filecopy: [Failed](https://openqa.qubes-os.org/tests/153722#step/windows_clipboard_and_filecopy/72) (test died)
 `# Test died: no candidate needle with tag(s) 'windows-Edge-address-...`

* system_tests_qwt_win11@hw13
  * windows_install: [wait_serial](https://openqa.qubes-os.org/tests/153723#step/windows_install/29) (wait serial expected)
 `# wait_serial expected: qr/qDqV_-\d+-/...`

  * windows_install: [Failed](https://openqa.qubes-os.org/tests/153723#step/windows_install/30) (test died + timed out)
 `# Test died: command 'script -e -c 'bash -x /usr/bin/qvm-create-win...`

* system_tests_extra
  * TC_00_QVCTest_whonix-gateway-17: [test_010_screenshare](https://openqa.qubes-os.org/tests/153754#step/TC_00_QVCTest_whonix-gateway-17/1) (failure)
 `~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^... AssertionError: 0 == 0`

* system_tests_guivm_vnc_gui_interactive
  * guivm_manager: [unnamed test](https://openqa.qubes-os.org/tests/153755#step/guivm_manager/7) (unknown)
  * guivm_manager: [Failed](https://openqa.qubes-os.org/tests/153755#step/guivm_manager/8) (test died)
 `# Test died: no candidate needle with tag(s) 'qubes-qube-manager' m...`

## Failed tests
<details><summary>15 failures</summary>

* system_tests_network
  * VmNetworking_fedora-42-xfce: [test_001_simple_networking_paused](https://openqa.qubes-os.org/tests/153691#step/VmNetworking_fedora-42-xfce/2) (failure)
 `AssertionError: 1 != 0 : Ping by IP on netvm=something -> netvm=som...`

* system_tests_backup
  * TC_00_Backup: [test_100_backup_dom0_no_restore](https://openqa.qubes-os.org/tests/153692#step/TC_00_Backup/7) (failure)
 `AssertionError: QubesException during backup_prepare: Can not backu...`

  * TC_00_Backup: [test_101_backup_dom0_to_homedir](https://openqa.qubes-os.org/tests/153692#step/TC_00_Backup/8) (failure)
 `AssertionError: QubesException during backup_prepare: Can not backu...`

* system_tests_pvgrub_salt_storage
  * StorageReflinkOnBtrfs: [test_003_snapshot](https://openqa.qubes-os.org/tests/153694#step/StorageReflinkOnBtrfs/4) (error + timeout + cleanup)
 `qubes.exc.QubesVMShutdownTimeoutError: Domain shutdown timed out: '...`

* system_tests_usbproxy
  * TC_20_USBProxy_core3_debian-13-xfce: [test_060_auto_detach_on_remove](https://openqa.qubes-os.org/tests/153699#step/TC_20_USBProxy_core3_debian-13-xfce/8) (failure)
 `AssertionError: 0 == 0 : Device disconnection failed`

* system_tests_network_ipv6
  * VmIPv6Networking_debian-13-xfce: [test_001_simple_networking_paused](https://openqa.qubes-os.org/tests/153701#step/VmIPv6Networking_debian-13-xfce/2) (failure)
 `AssertionError: 1 != 0 : Ping by IP on netvm=something -> netvm=som...`

* system_tests_qwt_win10_seamless@hw13
  * windows_clipboard_and_filecopy: [unnamed test](https://openqa.qubes-os.org/tests/153722#step/windows_clipboard_and_filecopy/71) (unknown)
  * windows_clipboard_and_filecopy: [Failed](https://openqa.qubes-os.org/tests/153722#step/windows_clipboard_and_filecopy/72) (test died)
 `# Test died: no candidate needle with tag(s) 'windows-Edge-address-...`

* system_tests_qwt_win11@hw13
  * windows_install: [wait_serial](https://openqa.qubes-os.org/tests/153723#step/windows_install/29) (wait serial expected)
 `# wait_serial expected: qr/qDqV_-\d+-/...`

  * windows_install: [Failed](https://openqa.qubes-os.org/tests/153723#step/windows_install/30) (test died + timed out)
 `# Test died: command 'script -e -c 'bash -x /usr/bin/qvm-create-win...`

* system_tests_dispvm_perf@hw7
  * TC_00_DispVMPerf_whonix-workstation-17: [test_027_dispvm_from_dom0_preload_gui](https://openqa.qubes-os.org/tests/153726#step/TC_00_DispVMPerf_whonix-workstation-17/14) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

* system_tests_extra
  * TC_00_QVCTest_whonix-gateway-17: [test_010_screenshare](https://openqa.qubes-os.org/tests/153754#step/TC_00_QVCTest_whonix-gateway-17/1) (failure)
 `~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^... AssertionError: 0 == 0`

  * TC_00_QVCTest_whonix-workstation-17: [test_010_screenshare](https://openqa.qubes-os.org/tests/153754#step/TC_00_QVCTest_whonix-workstation-17/1) (failure)
 `AssertionError: 1 != 0 : Timeout waiting for /dev/video0 in test-in...`

* system_tests_guivm_vnc_gui_interactive
  * guivm_manager: [unnamed test](https://openqa.qubes-os.org/tests/153755#step/guivm_manager/7) (unknown)
  * guivm_manager: [Failed](https://openqa.qubes-os.org/tests/153755#step/guivm_manager/8) (test died)
 `# Test died: no candidate needle with tag(s) 'qubes-qube-manager' m...`

</details>

## Fixed failures
Compared to: https://openqa.qubes-os.org/tests/149225#dependencies
<details><summary>82 fixed</summary>

* system_tests_dispvm
  * system_tests: [Fail](https://openqa.qubes-os.org/tests/149251#step/system_tests/27) (unknown)
 `Tests qubes.tests.integ.dispvm failed (exit code 1), details report...`

  * system_tests: [Failed](https://openqa.qubes-os.org/tests/149251#step/system_tests/110) (test died)
 `# Test died: Some tests failed at qubesos/tests/system_tests.pm lin...`

  * TC_20_DispVM_debian-13-xfce: [test_012_preload_low_mem](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/3) (failure)
 `~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^... AssertionError: 1 != 0`

  * TC_20_DispVM_debian-13-xfce: [test_013_preload_gui](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/4) (error)
 `raise KeyError(key)... KeyError: 'disp3723'`

  * TC_20_DispVM_debian-13-xfce: [test_014_preload_nogui](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/5) (error + cleanup)
 `raise TimeoutError from exc_val... TimeoutError`

  * TC_20_DispVM_debian-13-xfce: [test_015_preload_race_more](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/6) (error + cleanup)
 `raise KeyError(key)... KeyError: 'disp1187'`

  * TC_20_DispVM_debian-13-xfce: [test_016_preload_race_less](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/7) (failure + cleanup)
 `^^^^^^^^^^^^^^^^^^^^^^... AssertionError`

  * TC_20_DispVM_debian-13-xfce: [test_017_preload_autostart](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/8) (error)
 `raise KeyError(key)... KeyError: 'disp7317'`

  * TC_20_DispVM_debian-13-xfce: [test_018_preload_global](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/9) (error)
 `raise KeyError(key)... KeyError: 'disp8572'`

  * TC_20_DispVM_debian-13-xfce: [test_019_preload_refresh](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_debian-13-xfce/10) (error)
 `raise KeyError(key)... KeyError: 'disp6425'`

  * TC_20_DispVM_fedora-42-xfce: [test_012_preload_low_mem](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_fedora-42-xfce/3) (failure)
 `~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^... AssertionError: 1 != 0`

  * TC_20_DispVM_whonix-workstation-17: [test_012_preload_low_mem](https://openqa.qubes-os.org/tests/149251#step/TC_20_DispVM_whonix-workstation-17/3) (failure)
 `~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^... AssertionError: 1 != 0`

* system_tests_kde_gui_interactive
  * gui_keyboard_layout: [wait_serial](https://openqa.qubes-os.org/tests/149231#step/gui_keyboard_layout/26) (wait serial expected)
 `# wait_serial expected: "echo -e '[Layout]\nLayoutList=us,de' | sud...`

  * gui_keyboard_layout: [Failed](https://openqa.qubes-os.org/tests/149231#step/gui_keyboard_layout/56) (test died)
 `# Test died: command 'test "$(cd ~user;ls e1*)" = "$(qvm-run -p wor...`

* system_tests_audio
  * system_tests: [Fail](https://openqa.qubes-os.org/tests/149230#step/system_tests/27) (unknown)
 `Tests qubes.tests.integ.audio failed (exit code 1), details reporte...`

  * system_tests: [Failed](https://openqa.qubes-os.org/tests/149230#step/system_tests/98) (test died)
 `# Test died: Some tests failed at qubesos/tests/system_tests.pm lin...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_223_audio_play_hvm](https://openqa.qubes-os.org/tests/149230#step/TC_20_AudioVM_Pulse_whonix-workstation-17/4) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 120 seco...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_224_audio_rec_muted_hvm](https://openqa.qubes-os.org/tests/149230#step/TC_20_AudioVM_Pulse_whonix-workstation-17/5) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 120 seco...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_225_audio_rec_unmuted_hvm](https://openqa.qubes-os.org/tests/149230#step/TC_20_AudioVM_Pulse_whonix-workstation-17/6) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 120 seco...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_252_audio_playback_audiovm_switch_hvm](https://openqa.qubes-os.org/tests/149230#step/TC_20_AudioVM_Pulse_whonix-workstation-17/7) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 120 seco...`

* system_tests_audio@hw1
  * system_tests: [Fail](https://openqa.qubes-os.org/tests/149232#step/system_tests/27) (unknown)
 `Tests qubes.tests.integ.audio failed (exit code 1), details reporte...`

  * system_tests: [Failed](https://openqa.qubes-os.org/tests/149232#step/system_tests/82) (test died)
 `# Test died: Some tests failed at qubesos/tests/system_tests.pm lin...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_223_audio_play_hvm](https://openqa.qubes-os.org/tests/149232#step/TC_20_AudioVM_Pulse_whonix-workstation-17/4) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 60 secon...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_224_audio_rec_muted_hvm](https://openqa.qubes-os.org/tests/149232#step/TC_20_AudioVM_Pulse_whonix-workstation-17/5) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 60 secon...`

  * TC_20_AudioVM_Pulse_whonix-workstation-17: [test_252_audio_playback_audiovm_switch_hvm](https://openqa.qubes-os.org/tests/149232#step/TC_20_AudioVM_Pulse_whonix-workstation-17/7) (error)
 `qubes.exc.QubesVMError: Cannot connect to qrexec agent for 60 secon...`

* system_tests_dispvm_perf@hw7
  * system_tests: [wait_serial](https://openqa.qubes-os.org/tests/149241#step/system_tests/42) (wait serial expected)
 `# wait_serial expected: qr/D2qNh-\d+-/...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_000_dispvm](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/1) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_002_dispvm_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/3) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_006_dispvm_from_dom0](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/5) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_008_dispvm_from_dom0_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/7) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_020_dispvm_preload](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/9) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_021_dispvm_preload_gui](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/10) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_022_dispvm_preload_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/11) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_023_dispvm_preload_gui_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/12) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_026_dispvm_from_dom0_preload](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/13) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_027_dispvm_from_dom0_preload_gui](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/14) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_028_dispvm_from_dom0_preload_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/15) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_029_dispvm_from_dom0_preload_gui_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/16) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_400_dispvm_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/17) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_402_dispvm_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/19) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_404_dispvm_preload_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/21) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_404_dispvm_preload_less_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/22) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_404_dispvm_preload_more_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/23) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_405_dispvm_preload_gui_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/24) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_406_dispvm_preload_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/25) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_407_dispvm_preload_gui_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/26) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_900_vm](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/27) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_902_vm_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/29) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_904_vm_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/31) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_debian-13-xfce: [test_906_vm_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_debian-13-xfce/33) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_020_dispvm_preload](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/9) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_021_dispvm_preload_gui](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/10) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_022_dispvm_preload_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/11) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_023_dispvm_preload_gui_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/12) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_026_dispvm_from_dom0_preload](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/13) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_027_dispvm_from_dom0_preload_gui](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/14) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_028_dispvm_from_dom0_preload_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/15) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_029_dispvm_from_dom0_preload_gui_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/16) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_404_dispvm_preload_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/21) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_404_dispvm_preload_less_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/22) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_404_dispvm_preload_more_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/23) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_405_dispvm_preload_gui_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/24) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_406_dispvm_preload_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/25) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_fedora-42-xfce: [test_407_dispvm_preload_gui_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_fedora-42-xfce/26) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_020_dispvm_preload](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/9) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_021_dispvm_preload_gui](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/10) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_022_dispvm_preload_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/11) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_023_dispvm_preload_gui_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/12) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_026_dispvm_from_dom0_preload](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/13) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_028_dispvm_from_dom0_preload_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/15) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_029_dispvm_from_dom0_preload_gui_concurrent](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/16) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_404_dispvm_preload_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/21) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_404_dispvm_preload_less_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/22) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_404_dispvm_preload_more_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/23) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_405_dispvm_preload_gui_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/24) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_406_dispvm_preload_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/25) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

  * TC_00_DispVMPerf_whonix-workstation-17: [test_407_dispvm_preload_gui_concurrent_api](https://openqa.qubes-os.org/tests/149241#step/TC_00_DispVMPerf_whonix-workstation-17/26) (failure)
 `AssertionError: '/usr/lib/qubes/tests/dispvm_perf.py --dvm=test-ins...`

* system_tests_guivm_gpu_gui_interactive@hw13
  * guivm_startup: [wait_serial](https://openqa.qubes-os.org/tests/149270#step/guivm_startup/13) (wait serial expected)
 `# wait_serial expected: qr/lEcbc-\d+-/...`

  * guivm_startup: [Failed](https://openqa.qubes-os.org/tests/149270#step/guivm_startup/14) (test died + timed out)
 `# Test died: command '! qvm-check sys-whonix || time qvm-start sys-...`

* system_tests_basic_vm_qrexec_gui_ext4
  * system_tests: [Fail](https://openqa.qubes-os.org/tests/149272#step/system_tests/56) (unknown)
 `Tests qubes.tests.integ.vm_qrexec_gui failed (exit code 1), details...`

  * system_tests: [Failed](https://openqa.qubes-os.org/tests/149272#step/system_tests/97) (test died)
 `# Test died: Some tests failed at qubesos/tests/system_tests.pm lin...`

  * TC_20_NonAudio_whonix-gateway-17-pool: [test_012_qubes_desktop_run](https://openqa.qubes-os.org/tests/149272#step/TC_20_NonAudio_whonix-gateway-17-pool/4) (error + cleanup)
 `raise TimeoutError from exc_val... TimeoutError`

</details>

## Performance Tests

### Performance degradation:

<details><summary>12 performance degradations</summary>

* fedora-42-xfce_exec-data-duplex-root: 110.99 🔻 ( previous job: 96.36, degradation: 115.18%)
* whonix-gateway-17_exec-data-duplex: 75.30 🔻 ( previous job: 68.38, degradation: 110.12%)
* dom0_root_seq1m_q8t1_read 3:read_bandwidth_kb: 399914.00 🔻 ( previous job: 497426.00, degradation: 80.40%)
* dom0_root_seq1m_q8t1_write 3:write_bandwidth_kb: 112024.00 🔻 ( previous job: 265260.00, degradation: 42.23%)
* dom0_root_seq1m_q1t1_read 3:read_bandwidth_kb: 199236.00 🔻 ( previous job: 431512.00, degradation: 46.17%)
* dom0_root_seq1m_q1t1_write 3:write_bandwidth_kb: 44503.00 🔻 ( previous job: 196254.00, degradation: 22.68%)
* dom0_root_rnd4k_q32t1_read 3:read_bandwidth_kb: 20303.00 🔻 ( previous job: 23940.00, degradation: 84.81%)
* fedora-42-xfce_root_rnd4k_q1t1_write 3:write_bandwidth_kb: 1220.00 🔻 ( previous job: 1368.00, degradation: 89.18%)
* fedora-42-xfce_private_rnd4k_q1t1_read 3:read_bandwidth_kb: 7996.00 🔻 ( previous job: 8992.00, degradation: 88.92%)
* fedora-42-xfce_private_rnd4k_q1t1_write 3:write_bandwidth_kb: 424.00 🔻 ( previous job: 1251.00, degradation: 33.89%)
* fedora-42-xfce_volatile_seq1m_q1t1_write 3:write_bandwidth_kb: 41580.00 🔻 ( previous job: 64217.00, degradation: 64.75%)
* fedora-42-xfce_volatile_rnd4k_q1t1_write 3:write_bandwidth_kb: 1022.00 🔻 ( previous job: 2384.00, degradation: 42.87%)
</details>

### Remaining performance tests:

<details><summary>161 tests</summary>

* debian-13-xfce_exec: 7.47 🟢 ( previous job: 8.36, improvement: 89.35%)
* debian-13-xfce_exec-root: 26.78 🟢 ( previous job: 27.36, improvement: 97.89%)
* debian-13-xfce_socket: 8.25 🟢 ( previous job: 8.57, improvement: 96.29%)
* debian-13-xfce_socket-root: 8.21 🟢 ( previous job: 8.26, improvement: 99.46%)
* debian-13-xfce_exec-data-simplex: 62.35 🟢 ( previous job: 72.43, improvement: 86.08%)
* debian-13-xfce_exec-data-duplex: 71.04 🟢 ( previous job: 76.65, improvement: 92.68%)
* debian-13-xfce_exec-data-duplex-root: 89.89 🟢 ( previous job: 91.79, improvement: 97.93%)
* debian-13-xfce_socket-data-duplex: 136.04 🔻 ( previous job: 133.45, degradation: 101.95%)
* fedora-42-xfce_exec: 9.15 🔻 ( previous job: 9.06, degradation: 101.01%)
* fedora-42-xfce_exec-root: 58.50 🔻 ( previous job: 58.19, degradation: 100.53%)
* fedora-42-xfce_socket: 8.02 🟢 ( previous job: 8.48, improvement: 94.54%)
* fedora-42-xfce_socket-root: 8.63 🔻 ( previous job: 8.18, degradation: 105.47%)
* fedora-42-xfce_exec-data-simplex: 72.57 🟢 ( previous job: 78.48, improvement: 92.46%)
* fedora-42-xfce_exec-data-duplex: 68.29 🔻 ( previous job: 67.92, degradation: 100.55%)
* fedora-42-xfce_socket-data-duplex: 155.24 🔻 ( previous job: 142.58, degradation: 108.88%)
* whonix-gateway-17_exec: 6.97 🟢 ( previous job: 8.12, improvement: 85.85%)
* whonix-gateway-17_exec-root: 38.04 🟢 ( previous job: 41.05, improvement: 92.65%)
* whonix-gateway-17_socket: 6.79 🟢 ( previous job: 8.52, improvement: 79.61%)
* whonix-gateway-17_socket-root: 7.10 🟢 ( previous job: 8.12, improvement: 87.45%)
* whonix-gateway-17_exec-data-simplex: 75.69 🟢 ( previous job: 83.60, improvement: 90.54%)
* whonix-gateway-17_exec-data-duplex-root: 92.01 🟢 ( previous job: 99.37, improvement: 92.59%)
* whonix-gateway-17_socket-data-duplex: 173.41 🔻 ( previous job: 167.12, degradation: 103.77%)
* whonix-workstation-17_exec: 8.07 🔻 ( previous job: 7.57, degradation: 106.66%)
* whonix-workstation-17_exec-root: 56.64 🟢 ( previous job: 56.76, improvement: 99.79%)
* whonix-workstation-17_socket: 8.19 🟢 ( previous job: 8.59, improvement: 95.37%)
* whonix-workstation-17_socket-root: 9.34 🔻 ( previous job: 8.89, degradation: 105.10%)
* whonix-workstation-17_exec-data-simplex: 72.46 🔻 ( previous job: 66.80, degradation: 108.47%)
* whonix-workstation-17_exec-data-duplex: 76.97 🔻 ( previous job: 74.50, degradation: 103.31%)
* whonix-workstation-17_exec-data-duplex-root: 97.64 🟢 ( previous job: 102.34, improvement: 95.41%)
* whonix-workstation-17_socket-data-duplex: 157.30 🔻 ( previous job: 147.97, degradation: 106.30%)
* dom0_root_rnd4k_q32t1_write 3:write_bandwidth_kb: 4316.00 🟢 ( previous job: 2446.00, improvement: 176.45%)
* dom0_root_rnd4k_q1t1_read 3:read_bandwidth_kb: 10183.00 🟢 ( previous job: 5874.00, improvement: 173.36%)
* dom0_root_rnd4k_q1t1_write 3:write_bandwidth_kb: 4515.00 🟢 ( previous job: 29.00, improvement: 15568.97%)
* dom0_varlibqubes_seq1m_q8t1_read 3:read_bandwidth_kb: 310137.00 🟢 ( previous job: 292489.00, improvement: 106.03%)
* dom0_varlibqubes_seq1m_q8t1_write 3:write_bandwidth_kb: 148002.00 🟢 ( previous job: 110817.00, improvement: 133.56%)
* dom0_varlibqubes_seq1m_q1t1_read 3:read_bandwidth_kb: 440023.00 🟢 ( previous job: 137802.00, improvement: 319.32%)
* dom0_varlibqubes_seq1m_q1t1_write 3:write_bandwidth_kb: 162049.00 🟢 ( previous job: 121719.00, improvement: 133.13%)
* dom0_varlibqubes_rnd4k_q32t1_read 3:read_bandwidth_kb: 109810.00 🟢 ( previous job: 103932.00, improvement: 105.66%)
* dom0_varlibqubes_rnd4k_q32t1_write 3:write_bandwidth_kb: 6619.00 🟢 ( previous job: 6356.00, improvement: 104.14%)
* dom0_varlibqubes_rnd4k_q1t1_read 3:read_bandwidth_kb: 8340.00 🟢 ( previous job: 7695.00, improvement: 108.38%)
* dom0_varlibqubes_rnd4k_q1t1_write 3:write_bandwidth_kb: 3902.00 🔻 ( previous job: 3925.00, degradation: 99.41%)
* fedora-42-xfce_root_seq1m_q8t1_read 3:read_bandwidth_kb: 376238.00 🟢 ( previous job: 366891.00, improvement: 102.55%)
* fedora-42-xfce_root_seq1m_q8t1_write 3:write_bandwidth_kb: 181289.00 🟢 ( previous job: 140215.00, improvement: 129.29%)
* fedora-42-xfce_root_seq1m_q1t1_read 3:read_bandwidth_kb: 298909.00 🔻 ( previous job: 299764.00, degradation: 99.71%)
* fedora-42-xfce_root_seq1m_q1t1_write 3:write_bandwidth_kb: 48674.00 🟢 ( previous job: 47575.00, improvement: 102.31%)
* fedora-42-xfce_root_rnd4k_q32t1_read 3:read_bandwidth_kb: 85772.00 🔻 ( previous job: 86001.00, degradation: 99.73%)
* fedora-42-xfce_root_rnd4k_q32t1_write 3:write_bandwidth_kb: 2843.00 🔻 ( previous job: 3020.00, degradation: 94.14%)
* fedora-42-xfce_root_rnd4k_q1t1_read 3:read_bandwidth_kb: 8256.00 🔻 ( previous job: 9042.00, degradation: 91.31%)
* fedora-42-xfce_private_seq1m_q8t1_read 3:read_bandwidth_kb: 387930.00 🟢 ( previous job: 387500.00, improvement: 100.11%)
* fedora-42-xfce_private_seq1m_q8t1_write 3:write_bandwidth_kb: 165441.00 🟢 ( previous job: 136640.00, improvement: 121.08%)
* fedora-42-xfce_private_seq1m_q1t1_read 3:read_bandwidth_kb: 312821.00 🔻 ( previous job: 325139.00, degradation: 96.21%)
* fedora-42-xfce_private_seq1m_q1t1_write 3:write_bandwidth_kb: 89158.00 🟢 ( previous job: 79539.00, improvement: 112.09%)
* fedora-42-xfce_private_rnd4k_q32t1_read 3:read_bandwidth_kb: 91074.00 🟢 ( previous job: 87396.00, improvement: 104.21%)
* fedora-42-xfce_private_rnd4k_q32t1_write 3:write_bandwidth_kb: 4629.00 🟢 ( previous job: 3765.00, improvement: 122.95%)
* fedora-42-xfce_volatile_seq1m_q8t1_read 3:read_bandwidth_kb: 348017.00 🔻 ( previous job: 383531.00, degradation: 90.74%)
* fedora-42-xfce_volatile_seq1m_q8t1_write 3:write_bandwidth_kb: 175624.00 🟢 ( previous job: 157382.00, improvement: 111.59%)
* fedora-42-xfce_volatile_seq1m_q1t1_read 3:read_bandwidth_kb: 342336.00 🟢 ( previous job: 293225.00, improvement: 116.75%)
* fedora-42-xfce_volatile_rnd4k_q32t1_read 3:read_bandwidth_kb: 79254.00 🔻 ( previous job: 87141.00, degradation: 90.95%)
* fedora-42-xfce_volatile_rnd4k_q32t1_write 3:write_bandwidth_kb: 5403.00 🟢 ( previous job: 4098.00, improvement: 131.84%)
* fedora-42-xfce_volatile_rnd4k_q1t1_read 3:read_bandwidth_kb: 8227.00 🔻 ( previous job: 8804.00, degradation: 93.45%)
* debian-13-xfce_dispvm (mean:6.6): 79.20
* debian-13-xfce_dispvm-gui (mean:7.243): 86.92 🟢 ( previous job: 119.40, improvement: 72.79%)
* debian-13-xfce_dispvm-concurrent (mean:3.391): 40.69
* debian-13-xfce_dispvm-gui-concurrent (mean:3.864): 46.37 🟢 ( previous job: 64.59, improvement: 71.78%)
* debian-13-xfce_dispvm-dom0 (mean:6.904): 82.85
* debian-13-xfce_dispvm-dom0-gui (mean:8.308): 99.70 🟢 ( previous job: 127.44, improvement: 78.23%)
* debian-13-xfce_dispvm-dom0-concurrent (mean:3.472): 41.66
* debian-13-xfce_dispvm-dom0-gui-concurrent (mean:4.029): 48.35 🟢 ( previous job: 65.60, improvement: 73.71%)
* debian-13-xfce_dispvm-preload (mean:3.716): 44.59
* debian-13-xfce_dispvm-preload-gui (mean:4.27): 51.24
* debian-13-xfce_dispvm-preload-concurrent (mean:2.623): 31.48
* debian-13-xfce_dispvm-preload-gui-concurrent (mean:3.689): 44.27
* debian-13-xfce_dispvm-preload-dom0 (mean:3.855): 46.26
* debian-13-xfce_dispvm-preload-dom0-gui (mean:5.372): 64.46
* debian-13-xfce_dispvm-preload-dom0-concurrent (mean:3.333): 40.00
* debian-13-xfce_dispvm-preload-dom0-gui-concurrent (mean:3.984): 47.81
* debian-13-xfce_dispvm-api (mean:7.044): 84.52
* debian-13-xfce_dispvm-gui-api (mean:8.041): 96.50 🟢 ( previous job: 127.48, improvement: 75.69%)
* debian-13-xfce_dispvm-concurrent-api (mean:3.51): 42.12
* debian-13-xfce_dispvm-gui-concurrent-api (mean:4.139): 49.67 🟢 ( previous job: 65.39, improvement: 75.96%)
* debian-13-xfce_dispvm-preload-api (mean:3.974): 47.69
* debian-13-xfce_dispvm-preload-less-api (mean:6.502): 78.03
* debian-13-xfce_dispvm-preload-more-api (mean:4.048): 48.58
* debian-13-xfce_dispvm-preload-gui-api (mean:5.199): 62.38
* debian-13-xfce_dispvm-preload-concurrent-api (mean:3.231): 38.77
* debian-13-xfce_dispvm-preload-gui-concurrent-api (mean:3.941): 47.29
* debian-13-xfce_vm (mean:0.043): 0.52
* debian-13-xfce_vm-gui (mean:0.06): 0.73 🟢 ( previous job: 7.40, improvement: 9.81%)
* debian-13-xfce_vm-concurrent (mean:0.024): 0.29
* debian-13-xfce_vm-gui-concurrent (mean:0.027): 0.33 🟢 ( previous job: 7.33, improvement: 4.43%)
* debian-13-xfce_vm-api (mean:0.04): 0.48
* debian-13-xfce_vm-gui-api (mean:0.044): 0.53 🟢 ( previous job: 2.17, improvement: 24.18%)
* debian-13-xfce_vm-concurrent-api (mean:0.032): 0.38
* debian-13-xfce_vm-gui-concurrent-api (mean:0.034): 0.41 🟢 ( previous job: 1.82, improvement: 22.64%)
* fedora-42-xfce_dispvm (mean:7.122): 85.46 🟢 ( previous job: 111.99, improvement: 76.31%)
* fedora-42-xfce_dispvm-gui (mean:8.362): 100.35 🟢 ( previous job: 131.63, improvement: 76.24%)
* fedora-42-xfce_dispvm-concurrent (mean:3.707): 44.48 🟢 ( previous job: 57.25, improvement: 77.69%)
* fedora-42-xfce_dispvm-gui-concurrent (mean:4.479): 53.75 🟢 ( previous job: 74.72, improvement: 71.93%)
* fedora-42-xfce_dispvm-dom0 (mean:7.701): 92.41 🟢 ( previous job: 124.92, improvement: 73.97%)
* fedora-42-xfce_dispvm-dom0-gui (mean:8.993): 107.92 🟢 ( previous job: 147.17, improvement: 73.33%)
* fedora-42-xfce_dispvm-dom0-concurrent (mean:3.893): 46.71 🟢 ( previous job: 64.09, improvement: 72.88%)
* fedora-42-xfce_dispvm-dom0-gui-concurrent (mean:4.588): 55.05 🟢 ( previous job: 75.59, improvement: 72.83%)
* fedora-42-xfce_dispvm-preload (mean:4.114): 49.37 🟢 ( previous job: 69.72, improvement: 70.81%)
* fedora-42-xfce_dispvm-preload-gui (mean:4.866): 58.40 🟢 ( previous job: 79.21, improvement: 73.73%)
* fedora-42-xfce_dispvm-preload-concurrent (mean:3.028): 36.34 🟢 ( previous job: 49.89, improvement: 72.83%)
* fedora-42-xfce_dispvm-preload-gui-concurrent (mean:3.793): 45.52 🟢 ( previous job: 69.08, improvement: 65.90%)
* fedora-42-xfce_dispvm-preload-dom0 (mean:4.362): 52.34 🟢 ( previous job: 72.35, improvement: 72.35%)
* fedora-42-xfce_dispvm-preload-dom0-gui (mean:5.483): 65.80 🟢 ( previous job: 91.39, improvement: 72.00%)
* fedora-42-xfce_dispvm-preload-dom0-concurrent (mean:3.57): 42.83 🟢 ( previous job: 57.13, improvement: 74.98%)
* fedora-42-xfce_dispvm-preload-dom0-gui-concurrent (mean:4.262): 51.15 🟢 ( previous job: 67.89, improvement: 75.34%)
* fedora-42-xfce_dispvm-api (mean:7.847): 94.17 🟢 ( previous job: 128.15, improvement: 73.48%)
* fedora-42-xfce_dispvm-gui-api (mean:9.175): 110.10 🟢 ( previous job: 149.03, improvement: 73.87%)
* fedora-42-xfce_dispvm-concurrent-api (mean:3.86): 46.32 🟢 ( previous job: 66.32, improvement: 69.84%)
* fedora-42-xfce_dispvm-gui-concurrent-api (mean:4.771): 57.26 🟢 ( previous job: 77.33, improvement: 74.04%)
* fedora-42-xfce_dispvm-preload-api (mean:4.371): 52.45 🟢 ( previous job: 73.95, improvement: 70.93%)
* fedora-42-xfce_dispvm-preload-less-api (mean:7.139): 85.67 🟢 ( previous job: 116.39, improvement: 73.60%)
* fedora-42-xfce_dispvm-preload-more-api (mean:4.423): 53.08 🟢 ( previous job: 71.33, improvement: 74.41%)
* fedora-42-xfce_dispvm-preload-gui-api (mean:5.452): 65.42 🟢 ( previous job: 92.06, improvement: 71.06%)
* fedora-42-xfce_dispvm-preload-concurrent-api (mean:3.615): 43.38 🟢 ( previous job: 61.60, improvement: 70.42%)
* fedora-42-xfce_dispvm-preload-gui-concurrent-api (mean:4.284): 51.41 🟢 ( previous job: 77.66, improvement: 66.20%)
* fedora-42-xfce_vm (mean:0.032): 0.38 🟢 ( previous job: 9.19, improvement: 4.18%)
* fedora-42-xfce_vm-gui (mean:0.029): 0.35 🟢 ( previous job: 9.01, improvement: 3.93%)
* fedora-42-xfce_vm-concurrent (mean:0.017): 0.21 🟢 ( previous job: 8.88, improvement: 2.36%)
* fedora-42-xfce_vm-gui-concurrent (mean:0.023): 0.28 🟢 ( previous job: 9.15, improvement: 3.04%)
* fedora-42-xfce_vm-api (mean:0.033): 0.40 🟢 ( previous job: 2.24, improvement: 17.65%)
* fedora-42-xfce_vm-gui-api (mean:0.042): 0.50 🟢 ( previous job: 2.33, improvement: 21.43%)
* fedora-42-xfce_vm-concurrent-api (mean:0.028): 0.34 🟢 ( previous job: 1.62, improvement: 20.96%)
* fedora-42-xfce_vm-gui-concurrent-api (mean:0.029): 0.35 🟢 ( previous job: 2.20, improvement: 15.80%)
* whonix-workstation-17_dispvm (mean:7.506): 90.07 🟢 ( previous job: 123.87, improvement: 72.71%)
* whonix-workstation-17_dispvm-gui (mean:8.456): 101.47 🟢 ( previous job: 148.68, improvement: 68.25%)
* whonix-workstation-17_dispvm-concurrent (mean:4.081): 48.97 🟢 ( previous job: 77.00, improvement: 63.60%)
* whonix-workstation-17_dispvm-gui-concurrent (mean:5.023): 60.27 🟢 ( previous job: 89.18, improvement: 67.58%)
* whonix-workstation-17_dispvm-dom0 (mean:8.473): 101.67 🟢 ( previous job: 135.24, improvement: 75.18%)
* whonix-workstation-17_dispvm-dom0-gui (mean:9.551): 114.61 🟢 ( previous job: 159.23, improvement: 71.98%)
* whonix-workstation-17_dispvm-dom0-concurrent (mean:4.61): 55.33 🟢 ( previous job: 76.91, improvement: 71.94%)
* whonix-workstation-17_dispvm-dom0-gui-concurrent (mean:5.025): 60.30 🟢 ( previous job: 87.45, improvement: 68.95%)
* whonix-workstation-17_dispvm-preload (mean:7.775): 93.30 🟢 ( previous job: 124.31, improvement: 75.05%)
* whonix-workstation-17_dispvm-preload-gui (mean:8.444): 101.33 🟢 ( previous job: 138.71, improvement: 73.05%)
* whonix-workstation-17_dispvm-preload-concurrent (mean:4.059): 48.71 🟢 ( previous job: 66.00, improvement: 73.80%)
* whonix-workstation-17_dispvm-preload-gui-concurrent (mean:4.585): 55.02 🟢 ( previous job: 77.46, improvement: 71.04%)
* whonix-workstation-17_dispvm-preload-dom0 (mean:4.747): 56.96 🟢 ( previous job: 81.24, improvement: 70.11%)
* whonix-workstation-17_dispvm-preload-dom0-concurrent (mean:4.051): 48.61 🟢 ( previous job: 72.84, improvement: 66.74%)
* whonix-workstation-17_dispvm-preload-dom0-gui-concurrent (mean:4.846): 58.15 🟢 ( previous job: 87.14, improvement: 66.73%)
* whonix-workstation-17_dispvm-api (mean:8.65): 103.80 🟢 ( previous job: 140.50, improvement: 73.88%)
* whonix-workstation-17_dispvm-gui-api (mean:9.495): 113.94 🟢 ( previous job: 157.40, improvement: 72.39%)
* whonix-workstation-17_dispvm-concurrent-api (mean:4.385): 52.62 🟢 ( previous job: 76.06, improvement: 69.18%)
* whonix-workstation-17_dispvm-gui-concurrent-api (mean:4.786): 57.43 🟢 ( previous job: 87.18, improvement: 65.88%)
* whonix-workstation-17_dispvm-preload-api (mean:4.781): 57.38 🟢 ( previous job: 84.09, improvement: 68.23%)
* whonix-workstation-17_dispvm-preload-less-api (mean:7.574): 90.89 🟢 ( previous job: 126.04, improvement: 72.12%)
* whonix-workstation-17_dispvm-preload-more-api (mean:5.401): 64.81 🟢 ( previous job: 89.12, improvement: 72.73%)
* whonix-workstation-17_dispvm-preload-gui-api (mean:6.467): 77.60 🟢 ( previous job: 101.72, improvement: 76.29%)
* whonix-workstation-17_dispvm-preload-concurrent-api (mean:4.045): 48.54 🟢 ( previous job: 71.58, improvement: 67.82%)
* whonix-workstation-17_dispvm-preload-gui-concurrent-api (mean:5.064): 60.76 🟢 ( previous job: 88.24, improvement: 68.86%)
* whonix-workstation-17_vm (mean:0.046): 0.55 🟢 ( previous job: 9.27, improvement: 5.94%)
* whonix-workstation-17_vm-gui (mean:0.047): 0.57 🟢 ( previous job: 9.82, improvement: 5.76%)
* whonix-workstation-17_vm-concurrent (mean:0.027): 0.33 🟢 ( previous job: 8.93, improvement: 3.66%)
* whonix-workstation-17_vm-gui-concurrent (mean:0.031): 0.37 🟢 ( previous job: 9.38, improvement: 3.97%)
* whonix-workstation-17_vm-api (mean:0.043): 0.52 🟢 ( previous job: 2.56, improvement: 20.20%)
* whonix-workstation-17_vm-gui-api (mean:0.069): 0.82 🟢 ( previous job: 2.53, improvement: 32.62%)
* whonix-workstation-17_vm-concurrent-api (mean:0.029): 0.35 🟢 ( previous job: 1.81, improvement: 19.22%)
* whonix-workstation-17_vm-gui-concurrent-api (mean:0.033): 0.40 🟢 ( previous job: 2.57, improvement: 15.35%)
</details>


Would label it with: ['openqa-failed']